### PR TITLE
Fix get latest version for download page

### DIFF
--- a/download.html
+++ b/download.html
@@ -267,11 +267,11 @@
       </div>
 
       <script type="text/javascript">
-      var req = new XMLHttpRequest();
-      req.onreadystatechange = function() {
-          if (req.readyState == XMLHttpRequest.DONE) {
-             if (req.status == 200) {
-                var data = JSON.parse(req.responseText);
+      var reqDownload = new XMLHttpRequest();
+      reqDownload.onreadystatechange = function() {
+          if (reqDownload.readyState == XMLHttpRequest.DONE) {
+             if (reqDownload.status == 200) {
+                var data = JSON.parse(reqDownload.responseText);
                 var s = data.version + '';
                 var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
                 var year = s[0] + s[1];
@@ -285,16 +285,16 @@
              }
           }
       };
-      req.open("GET", "https://server.armorpaint.org/armorpaint.html", true);
-      req.send();
+      reqDownload.open("GET", "https://server.armorpaint.org/armorpaint.html", true);
+      reqDownload.send();
 
       let _onclick = document.getElementById('buy_button').onclick;
       document.getElementById('buy_button').onclick = function() {
         _onclick();
-        var req = new XMLHttpRequest();
-        req.onreadystatechange = function() {};
-        req.open("GET", "https://server.armorpaint.org/cart_armorpaint.html", true);
-        req.send();
+        var reqDownload = new XMLHttpRequest();
+        reqDownload.onreadystatechange = function() {};
+        reqDownload.open("GET", "https://server.armorpaint.org/cart_armorpaint.html", true);
+        reqDownload.send();
 
       }
       </script>

--- a/src/download.html
+++ b/src/download.html
@@ -134,11 +134,11 @@
       </div>
 
       <script type="text/javascript">
-      var req = new XMLHttpRequest();
-      req.onreadystatechange = function() {
-          if (req.readyState == XMLHttpRequest.DONE) {
-             if (req.status == 200) {
-                var data = JSON.parse(req.responseText);
+      var reqDownload = new XMLHttpRequest();
+      reqDownload.onreadystatechange = function() {
+          if (reqDownload.readyState == XMLHttpRequest.DONE) {
+             if (reqDownload.status == 200) {
+                var data = JSON.parse(reqDownload.responseText);
                 var s = data.version + '';
                 var months = ['January','February','March','April','May','June','July','August','September','October','November','December'];
                 var year = s[0] + s[1];
@@ -152,16 +152,16 @@
              }
           }
       };
-      req.open("GET", "https://server.armorpaint.org/armorpaint.html", true);
-      req.send();
+      reqDownload.open("GET", "https://server.armorpaint.org/armorpaint.html", true);
+      reqDownload.send();
 
       let _onclick = document.getElementById('buy_button').onclick;
       document.getElementById('buy_button').onclick = function() {
         _onclick();
-        var req = new XMLHttpRequest();
-        req.onreadystatechange = function() {};
-        req.open("GET", "https://server.armorpaint.org/cart_armorpaint.html", true);
-        req.send();
+        var reqDownload = new XMLHttpRequest();
+        reqDownload.onreadystatechange = function() {};
+        reqDownload.open("GET", "https://server.armorpaint.org/cart_armorpaint.html", true);
+        reqDownload.send();
 
       }
       </script>


### PR DESCRIPTION
# TL;TR

You were using the same naming convention `req` to define multiple variables. This lead to your 'get latest release version' code being overridden by earlier code with the same variable name.

# Steps to Reproduce Issue
### Version 1

Go to homepage.

![image](https://github.com/armory3d/armorpaint_web/assets/69180012/a5c4a562-b255-42d8-a243-46a0359c9e86)

Go to download page.

![image](https://github.com/armory3d/armorpaint_web/assets/69180012/0ef547a8-ba9c-4994-81af-6047e74a65d5)

Refresh page (no clear cache required).

![image](https://github.com/armory3d/armorpaint_web/assets/69180012/737fefdc-cde9-41dc-bec8-fcd215ebe75b)

### Version 2

Go to download page directly (without going to any of the other pages or without cache).

![image](https://github.com/armory3d/armorpaint_web/assets/69180012/737fefdc-cde9-41dc-bec8-fcd215ebe75b)
