### PR TITLE
Fix dropdown, tooltip, & link

### DIFF
--- a/download.html
+++ b/download.html
@@ -200,10 +200,11 @@
                 game: "armorpaint"
               });
             </script>
-            <script src="css/bootstrap.bundle.min.js"></script>
             <script type="text/javascript">
-              const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
-              const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+              window.onload = () => {
+                const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+                const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+              };
             </script>
           </div>
 
@@ -249,7 +250,7 @@
             <h1 class="display-5 text-body-emphasis lh-1 mb-3">Latest Release</h1>
             <p class="lead">Version: <span id="spanversion">...</span></p>
             <p class="lead">Updated: <span id="spanupdated">...</span></p>
-            <p class="lead"><a href="https://armorpaint.org/notes.html">What's New</a></p>
+            <p class="lead"><a href="https://armorpaint.org/notes">What's New</a></p>
             <p>🖌🎨</p>
           </div>
         </div>

--- a/src/download.html
+++ b/src/download.html
@@ -67,10 +67,11 @@
                 game: "armorpaint"
               });
             </script>
-            <script src="css/bootstrap.bundle.min.js"></script>
             <script type="text/javascript">
-              const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
-              const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+              window.onload = () => {
+                const tooltipTriggerList = document.querySelectorAll('[data-bs-toggle="tooltip"]');
+                const tooltipList = [...tooltipTriggerList].map(tooltipTriggerEl => new bootstrap.Tooltip(tooltipTriggerEl));
+              };
             </script>
           </div>
 
@@ -116,7 +117,7 @@
             <h1 class="display-5 text-body-emphasis lh-1 mb-3">Latest Release</h1>
             <p class="lead">Version: <span id="spanversion">...</span></p>
             <p class="lead">Updated: <span id="spanupdated">...</span></p>
-            <p class="lead"><a href="https://armorpaint.org/notes.html">What's New</a></p>
+            <p class="lead"><a href="https://armorpaint.org/notes">What's New</a></p>
             <p>🖌🎨</p>
           </div>
         </div>


### PR DESCRIPTION
# Bugs
### Problem 1

Site, dropdown menu is broken (it should be visible whenever the button/hyperlink is clicked).

![image](https://github.com/armory3d/armorpaint_web/assets/69180012/d1a58c90-871c-41b2-85c7-8f5aded66f25)

### Problem 2

Tooltip is _**sometimes**_ broken (it should always be visible whenever text is hovered).

![image](https://github.com/armory3d/armorpaint_web/assets/69180012/a2e69b4f-d6be-4610-82b0-68a50951998d)

### Problem 3

Unnecessary suffix extension (`.html`).

![image](https://github.com/armory3d/armorpaint_web/assets/69180012/28d00ff1-efc5-48dd-afd8-d7e214fbc06c)

# Solutions

1. Remove duplicate Bootstrap JS import - page was importing Bootstrap JS twice (it should only be imported in `footer.html`) and confusing the code.
2. Wait until Bootstrap JS is loaded - _**sometimes**_, the page is attempting to access the Bootstrap module before Bootstrap JS is fully imported. Please note that this bug doesn't always happen, but whenever it does, there is a console error that states Bootstrap is undefined / not found.
3. Removed unnecessary suffix (`.html`) - it's not needed and looks unprofessional.